### PR TITLE
Cloudwatch

### DIFF
--- a/.github/workflows/cloudwatch.yaml
+++ b/.github/workflows/cloudwatch.yaml
@@ -1,4 +1,3 @@
-
 name: Start CloudWatch Agent via SSM
 
 on:
@@ -43,12 +42,16 @@ jobs:
             --query "Reservations[].Instances[].InstanceId" --output text)
           echo "instance_id=$INSTANCE_ID" >> $GITHUB_OUTPUT
 
-      - name: Run CloudWatch Agent setup script on EC2
+      - name: Run CloudWatch Agent setup script via SSM
         run: |
           aws ssm send-command \
             --targets "Key=InstanceIds,Values=${{ steps.instance.outputs.instance_id }}" \
             --document-name "AWS-RunShellScript" \
             --comment "Start CloudWatch Agent" \
-            --parameters 'commands=["curl -fsSL https://raw.githubusercontent.com/Ajinkya-A3/tech_eazy_devops_Ajinkya-A3/cloudwatch/Scripts/cloudwatch.sh | sudo bash"]' \
-            --cloud-watch-output-config '{"CloudWatchLogGroupName":"ssm-command-logs","CloudWatchOutputEnabled":true}'
-
+            --parameters 'commands=[
+              "curl -fsSL https://raw.githubusercontent.com/Ajinkya-A3/tech_eazy_devops_Ajinkya-A3/cloudwatch/Scripts/cloudwatch.sh -o /tmp/cloudwatch.sh",
+              "chmod +x /tmp/cloudwatch.sh",
+              "bash /tmp/cloudwatch.sh"
+            ]' \
+            --region ap-south-2 \
+            --cloud-watch-output-config "CloudWatchLogGroupName=ssm-command-logs,CloudWatchOutputEnabled=true"

--- a/.github/workflows/cloudwatch.yaml
+++ b/.github/workflows/cloudwatch.yaml
@@ -1,1 +1,54 @@
 
+name: Start CloudWatch Agent via SSM
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Select environment (dev or prod)"
+        required: true
+        default: "dev"
+        type: choice
+        options:
+          - dev
+          - prod
+
+jobs:
+  start-cloudwatch-agent:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-south-2
+
+      - name: Get AWS account ID
+        id: account
+        run: |
+          ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+          echo "account_id=$ACCOUNT_ID" >> $GITHUB_OUTPUT
+
+      - name: Find EC2 instance ID by environment tag
+        id: instance
+        run: |
+          ENV=${{ github.event.inputs.environment }}
+          INSTANCE_ID=$(aws ec2 describe-instances \
+            --filters "Name=tag:Name,Values=techeazy-$ENV" "Name=instance-state-name,Values=running" \
+            --query "Reservations[].Instances[].InstanceId" --output text)
+          echo "instance_id=$INSTANCE_ID" >> $GITHUB_OUTPUT
+
+      - name: Run CloudWatch Agent setup script on EC2
+        run: |
+          aws ssm send-command \
+            --targets "Key=InstanceIds,Values=${{ steps.instance.outputs.instance_id }}" \
+            --document-name "AWS-RunShellScript" \
+            --comment "Start CloudWatch Agent" \
+            --parameters 'commands=[
+              "sudo bash -c '\''$(curl -s https://raw.githubusercontent.com/Ajinkya-A3/tech_eazy_devops_Ajinkya-A3/cloudwatch/Scripts/cloudwatch.sh)'\''"
+            ]'

--- a/.github/workflows/cloudwatch.yaml
+++ b/.github/workflows/cloudwatch.yaml
@@ -49,6 +49,6 @@ jobs:
             --targets "Key=InstanceIds,Values=${{ steps.instance.outputs.instance_id }}" \
             --document-name "AWS-RunShellScript" \
             --comment "Start CloudWatch Agent" \
-            --parameters 'commands=[
-              "sudo bash -c '\''$(curl -s https://raw.githubusercontent.com/Ajinkya-A3/tech_eazy_devops_Ajinkya-A3/cloudwatch/Scripts/cloudwatch.sh)'\''"
-            ]'
+            --parameters 'commands=["curl -fsSL https://raw.githubusercontent.com/Ajinkya-A3/tech_eazy_devops_Ajinkya-A3/cloudwatch/Scripts/cloudwatch.sh | sudo bash"]' \
+            --cloud-watch-output-config '{"CloudWatchLogGroupName":"ssm-command-logs","CloudWatchOutputEnabled":true}'
+

--- a/Scripts/cloudwatch.sh
+++ b/Scripts/cloudwatch.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+set -e
+
+# ------------------------------
+# VARIABLES
+# ------------------------------
+LOG_DIR=/home/ubuntu/logs/app
+CW_CONFIG=/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
+
+# ------------------------------
+# 1. Install CloudWatch Agent
+# ------------------------------
+cd /tmp
+curl -O https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/amd64/latest/amazon-cloudwatch-agent.deb
+sudo dpkg -i -E ./amazon-cloudwatch-agent.deb
+
+# ------------------------------
+# 2. Create persistent CloudWatch Agent JSON config
+# ------------------------------
+sudo tee $CW_CONFIG <<'EOF'
+{
+  "logs": {
+    "logs_collected": {
+      "files": {
+        "collect_list": [
+          {
+            "file_path": "/home/ubuntu/logs/app/app.out.log",
+            "log_group_name": "app-log-group",
+            "log_stream_name": "{instance_id}-out",
+            "timezone": "UTC"
+          },
+          {
+            "file_path": "/home/ubuntu/logs/app/app.err.log",
+            "log_group_name": "app-log-group",
+            "log_stream_name": "{instance_id}-err",
+            "timezone": "UTC"
+          }
+        ]
+      }
+    }
+  }
+}
+EOF
+
+# ------------------------------
+# 3. Start CloudWatch Agent
+# ------------------------------
+sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl \
+  -a fetch-config -m ec2 \
+  -c file:$CW_CONFIG \
+  -s
+
+# ------------------------------
+# 4. Check status and restart if needed
+# ------------------------------
+STATUS=$(/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a status | grep "running")
+if [ -z "$STATUS" ]; then
+    echo "CloudWatch Agent not running. Restarting..."
+    sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl \
+      -a fetch-config -m ec2 -c file:$CW_CONFIG -s
+else
+    echo "CloudWatch Agent is running."
+fi

--- a/Scripts/user_data.sh
+++ b/Scripts/user_data.sh
@@ -32,29 +32,29 @@ sudo nohup java -jar target/hellomvc-0.0.1-SNAPSHOT.jar \
 
 
 # Schedule log upload and shutdown
-cat <<'EOF' | at now + 3 minutes
-#!/bin/bash
+# cat <<'EOF' | at now + 3 minutes
+# #!/bin/bash
 
-# Set PATH so aws CLI and other tools are available
-export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+# # Set PATH so aws CLI and other tools are available
+# export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 
 
-# Ensure AWS credentials are active (via instance profile)
-aws sts get-caller-identity > /dev/null 2>&1
+# # Ensure AWS credentials are active (via instance profile)
+# aws sts get-caller-identity > /dev/null 2>&1
 
-# Make sure logs are readable
-sudo chmod -R a+r /home/ubuntu/logs
+# # Make sure logs are readable
+# sudo chmod -R a+r /home/ubuntu/logs
 
-# Copy EC2 system logs
-sudo cp /var/log/cloud-init.log /home/ubuntu/logs/ec2/
-sudo cp /var/log/cloud-init-output.log /home/ubuntu/logs/ec2/
+# # Copy EC2 system logs
+# sudo cp /var/log/cloud-init.log /home/ubuntu/logs/ec2/
+# sudo cp /var/log/cloud-init-output.log /home/ubuntu/logs/ec2/
 
-# Upload logs to S3
-aws s3 cp /home/ubuntu/logs/ec2/ s3://${s3_bucket_name}/logs/ec2/ --recursive
-aws s3 cp /home/ubuntu/logs/app/ s3://${s3_bucket_name}/logs/app/ --recursive
+# # Upload logs to S3
+# aws s3 cp /home/ubuntu/logs/ec2/ s3://${s3_bucket_name}/logs/ec2/ --recursive
+# aws s3 cp /home/ubuntu/logs/app/ s3://${s3_bucket_name}/logs/app/ --recursive
 
-# Shutdown the instance
-sudo shutdown -h now
-EOF
+# # Shutdown the instance
+# sudo shutdown -h now
+# EOF
 

--- a/Terraform/cloudwatch.tf
+++ b/Terraform/cloudwatch.tf
@@ -1,0 +1,31 @@
+resource "aws_cloudwatch_log_group" "app_logs" {
+  name              = "app-log-group"
+  retention_in_days = 7
+}
+
+
+resource "aws_cloudwatch_log_metric_filter" "error_filter" {
+  name           = "app-error-filter"
+  log_group_name = aws_cloudwatch_log_group.app_logs.name
+  pattern        = "ERROR "
+
+  metric_transformation {
+    name      = "AppErrorCount"
+    namespace = "AppLogs"
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "error_alarm" {
+  alarm_name          = "app-error-alarm"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 1
+  metric_name         = aws_cloudwatch_log_metric_filter.error_filter.metric_transformation[0].name
+  namespace           = "AppLogs"
+  period              = 60
+  statistic           = "Sum"
+  threshold           = 1
+
+  alarm_description = "Triggers if error logs appear"
+  alarm_actions     = [aws_sns_topic.app_alerts.arn]
+}

--- a/Terraform/sns.tf
+++ b/Terraform/sns.tf
@@ -1,0 +1,9 @@
+resource "aws_sns_topic" "app_alerts" {
+  name = "app-alerts-topic"
+}
+
+resource "aws_sns_topic_subscription" "email_alert" {
+  topic_arn = aws_sns_topic.app_alerts.arn
+  protocol  = "email"
+  endpoint  = "ajinkyaa3xd@gmail.com"
+}

--- a/policies/ec2_policy.json
+++ b/policies/ec2_policy.json
@@ -33,6 +33,38 @@
         "logs:DescribeLogStreams"
       ],
       "Resource": "*"
+    },
+    {
+      "Sid": "AllowSSMAgent",
+      "Effect": "Allow",
+      "Action": [
+        "ssm:DescribeAssociation",
+        "ssm:GetDeployablePatchSnapshotForInstance",
+        "ssm:GetDocument",
+        "ssm:DescribeDocument",
+        "ssm:GetManifest",
+        "ssm:GetParameter",
+        "ssm:GetParameters",
+        "ssm:ListAssociations",
+        "ssm:ListInstanceAssociations",
+        "ssm:PutInventory",
+        "ssm:PutComplianceItems",
+        "ssm:PutConfigurePackageResult",
+        "ssm:UpdateAssociationStatus",
+        "ssm:UpdateInstanceAssociationStatus",
+        "ssm:UpdateInstanceInformation",
+        "ssmmessages:CreateControlChannel",
+        "ssmmessages:CreateDataChannel",
+        "ssmmessages:OpenControlChannel",
+        "ssmmessages:OpenDataChannel",
+        "ec2messages:AcknowledgeMessage",
+        "ec2messages:DeleteMessage",
+        "ec2messages:FailMessage",
+        "ec2messages:GetEndpoint",
+        "ec2messages:GetMessages",
+        "ec2messages:SendReply"
+      ],
+      "Resource": "*"
     }
   ]
 }

--- a/policies/ec2_policy.json
+++ b/policies/ec2_policy.json
@@ -1,7 +1,6 @@
 {
   "Version": "2012-10-17",
   "Statement": [
-    
     {
       "Sid": "AllowPutOnlyOnBucket",
       "Effect": "Allow",
@@ -23,6 +22,17 @@
           "s3:prefix": "logs/*"
         }
       }
+    },
+    {
+      "Sid": "AllowCloudWatchLogs",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents",
+        "logs:DescribeLogStreams"
+      ],
+      "Resource": "*"
     }
   ]
 }


### PR DESCRIPTION
# Pull Request: CloudWatch Agent Setup via SSM & Error Simulation

## Summary

This PR introduces a fully automated way to:

1. Install and configure the **AWS CloudWatch Agent** on EC2 instances.
2. Start the agent using **AWS SSM** via GitHub Actions.
3. Stream application logs (`app.out.log` and `app.err.log`) to CloudWatch.
4. Provide a mechanism to **simulate errors** for testing log streaming.

---

## Changes Made


### 1. GitHub Actions Workflow
- New workflow `cloudwatch.yml` triggered via `workflow_dispatch`.
- Input parameter `environment` to select **dev** or **prod** instance.
- Finds EC2 instance by tag `Name=techeazy-${environment}`.
- Runs `cloudwatch.sh` on the target EC2 via **SSM**, with:
  - Script downloaded and executed explicitly (`curl -> chmod -> bash`).
  - CloudWatch output enabled for command logs.
- Logs are now streamed to `ssm-command-logs` CloudWatch group.

### 2. Error Simulation Script
- Added a simple command to append simulated error messages to `app.err.log`:
  ```bash
  for i in {1..3}; do
    echo "ERROR: Simulated failure #$i $(date)" >> /home/ubuntu/logs/app/app.err.log
    sleep 5
  done

### 3. SNS Alerts for Errors
- Configured **CloudWatch Logs Metric Filter** to detect `"ERROR"` strings in `app.err.log`.
- Metric triggers a **CloudWatch Alarm** if errors occur within 1 minute.
- Alarm action sends a notification to a pre-defined **SNS topic**.
- Enables immediate alerting  for quick response.
